### PR TITLE
Make sure that the form re-renders when the context is changed externally

### DIFF
--- a/src/ui/form/components/num-text.tsx
+++ b/src/ui/form/components/num-text.tsx
@@ -48,7 +48,8 @@ const _TextualInput = React.memo(function MTextualInput({ id, isDisabled, text, 
         Object.is(prevProps.isDisabled, nextProps.isDisabled) &&
         Object.is(prevProps.text, nextProps.text) &&
         Object.is(prevProps.isValid, nextProps.isValid) &&
-        Object.is(prevProps.noRightOffset, nextProps.noRightOffset)
+        Object.is(prevProps.noRightOffset, nextProps.noRightOffset) &&
+        Object.is(prevProps.onChange, nextProps.onChange)
     );
 });
 
@@ -81,11 +82,13 @@ export function TextualInput(props: Props) {
     // WARNING: The text above is referenced in other parts of code. Keep that in mind if you
     //          modify it.
     const [localValue, setLocalValue] = React.useState(initialState(handler, props.path));
-    const onChange = (text: string) => {
+
+    const onChange = React.useMemo(() => (text: string) => {
         const newValue = Value.textual(text, props.validator ? props.validator(text) : true);
         handler.set(props.path, newValue, newValue.isValid === localValue.isValid && !props.alwaysUpdate);
         setLocalValue({ text, isValid: newValue.isValid });
-    };
+    }, [props.path, props.validator, props.alwaysUpdate]);
+
     React.useEffect(() => {
         const value = handler.getValue(props.path);
         const text = Value.toTextual(value);

--- a/src/ui/form/components/num-text.tsx
+++ b/src/ui/form/components/num-text.tsx
@@ -27,20 +27,18 @@ const _TextualInput = React.memo(function MTextualInput({ id, isDisabled, text, 
     noRightOffset?: boolean,
 }) {
     return (
-        <>
-            <SInput
-                className={clsx(!noRightOffset && 'mbdbi-right-offset')}
-                id={id}
-                type='text'
-                value={text}
-                error={!isValid}
-                onChange={(_ev, data) => {
-                    onChange(data.value)
-                }}
-                disabled={isDisabled}
-                fluid
-            />
-        </>
+        <SInput
+            className={clsx(!noRightOffset && 'mbdbi-right-offset')}
+            id={id}
+            type='text'
+            value={text}
+            error={!isValid}
+            onChange={(_ev, data) => {
+                onChange(data.value)
+            }}
+            disabled={isDisabled}
+            fluid
+        />
     );
 }, (prevProps, nextProps) => {
     return (

--- a/src/ui/form/custom-components/components/value-error.tsx
+++ b/src/ui/form/custom-components/components/value-error.tsx
@@ -6,7 +6,7 @@ import { CustomComponent, DataError } from '../';
 import { PathId } from '../../path-id';
 import { ItemLabel } from '../../components/label';
 import { FloatInput } from '../../components/num-text';
-import { YesNoUnset } from '../../components/yes-no';
+import { TristateInput } from '../../components/yes-no';
 import { FormContextInstance } from '../../../../context';
 import { MbdbData } from '../../../../mbdb/data';
 import { Options } from '../../../../mbdb/deserialize';
@@ -188,6 +188,12 @@ export const ValueError: CustomComponent<ValueErrorData> = {
         const { handler } = React.useContext(FormContextInstance);
         const isMarkedEmpty = handler.isGroupMarkedEmpty(path);
 
+        const numValidator = React.useMemo(() => (v: string) => isMarkedEmpty || isDisabled ? true : validatorRequired(v), [isMarkedEmpty, isDisabled]);
+        const lowerErrorPath = React.useMemo(() => Data.Path.path('lower_error', path), [path]);
+        const upperErrorPath = React.useMemo(() => Data.Path.path('upper_error', path), [path]);
+        const errorLevelPath = React.useMemo(() => Data.Path.path('error_level', path), [path]);
+        const errorsAreRelativePath = React.useMemo(() => Data.Path.path('errors_are_relative', path), [path]);
+
         return (
             <React.Fragment key={reactKey}>
                 <ItemLabel label='Value error' markAsRequired={false} id={id} />
@@ -206,8 +212,8 @@ export const ValueError: CustomComponent<ValueErrorData> = {
                         <FloatInput
                             label='Min'
                             help={getHelp(help, 'lower_error')}
-                            path={Data.Path.path('lower_error', path)}
-                            validator={(v) => isMarkedEmpty || isDisabled ? true : validatorRequired(v)}
+                            path={lowerErrorPath}
+                            validator={numValidator}
                             isRequired={Required.lower_error}
                             isDisabled={isMarkedEmpty || isDisabled}
                         />
@@ -216,8 +222,8 @@ export const ValueError: CustomComponent<ValueErrorData> = {
                         <FloatInput
                             label='Max'
                             help={getHelp(help, 'upper_error')}
-                            path={Data.Path.path('upper_error', path)}
-                            validator={(v) => isMarkedEmpty || isDisabled ? true : validatorRequired(v)}
+                            path={upperErrorPath}
+                            validator={numValidator}
                             isRequired={Required.upper_error}
                             isDisabled={isMarkedEmpty || isDisabled}
                         />
@@ -226,20 +232,21 @@ export const ValueError: CustomComponent<ValueErrorData> = {
                         <FloatInput
                             label='Error level'
                             help={getHelp(help, 'error_level')}
-                            path={Data.Path.path('error_level', path)}
-                            validator={(v) => isMarkedEmpty || isDisabled ? true : validatorRequired(v)}
+                            path={errorLevelPath}
+                            validator={numValidator}
                             isRequired={Required.upper_error}
                             isDisabled={isMarkedEmpty || isDisabled}
                         />
                     </div>
                     <ItemLabel id={idIsRel} markAsRequired={false} help={getHelp(help, 'errors_are_relative')} label='Errors are relative' />
-                    <YesNoUnset
-                        id={idIsRel}
-                        isDisabled={isMarkedEmpty || isDisabled}
-                        isRequired={Required.errors_are_relative}
-                        path={Data.Path.path('errors_are_relative', path)}
-                        handler={handler}
-                    />
+                    <div>
+                        <TristateInput
+                            label=''
+                            isDisabled={isMarkedEmpty || isDisabled}
+                            isRequired={Required.errors_are_relative}
+                            path={errorsAreRelativePath}
+                        />
+                    </div>
                 </div>
             </React.Fragment>
         );


### PR DESCRIPTION
Memoized components would not detect that the values they are displaying have changed in the underlying data object. The most obvious example is when data is loaded into the form from a file. The fix trades some rendering efficiency for correctness. Real impact of this change from the user perspective needs to be looked at. Unfortunately, this issue was not discovered sooner.