### PR TITLE
Make sure that we fetch the entire vocabulary

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,7 @@ const ConfigObj = {
     baseUrl: '',
     isDevel: false as boolean,
     vocabulariesApiEndpoint: '',
+    vocabulariesApiMaximumHitsCap: void 0 as (undefined | number),
 };
 export type AppConfig = typeof ConfigObj;
 

--- a/src/mbdb/deserialize.ts
+++ b/src/mbdb/deserialize.ts
@@ -160,12 +160,11 @@ async function toInternalDataItem(item: Item, mbdbData: MbdbData, itemPath: Path
                     throw new Error(`Item on MbdbPath "${item.mbdbPath}" is a Vocabulary item but its id has a wrong type.`);
                 } else {
                     try {
-                        const voc = await Vocabulary.get(item.vocabularyType);
-                        const vocItem = voc.find((e) => e.id === id);
-                        if (vocItem === undefined) {
+                        const vocEntry = await Vocabulary.getById(item.vocabularyType, id);
+                        if (vocEntry === undefined) {
                             throw new Error(`Item on MbdbPath "${item.mbdbPath}" is a Vocabulary item but its id does not exist in the vocabulary that is currently available.`);
                         } else {
-                            Data.set(data, itemPath, Value.vocabularyEntry(id, vocItem.title.en, vocItem, true));
+                            Data.set(data, itemPath, Value.vocabularyEntry(id, vocEntry.title.en, vocEntry, true));
                         }
                     } catch (e) {
                         console.warn(`Failed to fetch vocabulary "${item.vocabularyType}" for item on MbdbPath "${item.mbdbPath}".`);

--- a/src/mbdb/vocabulary.ts
+++ b/src/mbdb/vocabulary.ts
@@ -15,7 +15,60 @@ export type Vocabulary = VocabularyEntry[];
 
 const Cache = new Map<string, Vocabulary>;
 
-function makeUrl(type: string) {
+async function getTotalHits(type: string) {
+    const url = makeUrl(type);
+    const pending = issueRequest(url);
+
+    const resp = await Net.resolveFetch(pending);
+    if (!resp.ok) {
+        throw new Error(`"Error ${resp.status}" response to vocabulary request for "${type}" vocabulary type.`);
+    }
+
+    const payload = await resp.json();
+    const totalHits = payload['hits']?.['total'];
+    if (typeof totalHits !== 'number' || totalHits < 0) {
+        throw new Error(`Unexpected response to vocabulary request for "${type}" vocabulary type. Invalid number of total hits.`);
+    }
+
+    return totalHits;
+}
+
+async function getVocabularyItems(type: string, totalHits: number) {
+    const url = makeUrl(type, totalHits);
+    const pending = issueRequest(url);
+
+    const resp = await Net.resolveFetch(pending);
+    if (!resp.ok) {
+        throw new Error(`"Error ${resp.status}" response to vocabulary request for "${type}" vocabulary type.`);
+    }
+
+    const payload = await resp.json();
+    const voc = payload['hits']?.['hits'];
+    if (!voc) {
+        throw new Error(`Unexpected response to vocabulary request for "${type}" vocabulary type.`);
+    }
+    if (!isVocabulary(voc)) {
+        throw new Error(`Vocabulary "${type}" does not conform to the expected schema.`)
+    }
+
+    return voc;
+}
+
+function issueRequest(url: string) {
+    return Net.fetchWithTimeout(
+        url,
+        {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            cache: 'no-cache',
+        },
+        15000
+    );
+}
+
+function makeUrl(type: string, size?: number) {
     if (!Config.get('vocabulariesApiEndpoint')) {
         throw new Error('Cannot make a URL for vocabulary API query because the application is misconfigured.');
     }
@@ -23,7 +76,12 @@ function makeUrl(type: string) {
     // BEWARE, BEWARE, BEWARE:
     // The inconsistency, or rather lack of thereof, is about the hit you in the face.
     // This URL shall *not* end with a trailing slash, otherwise the API request will fail.
-    return `${Config.get('baseUrl')}/api/${Config.get('vocabulariesApiEndpoint')}/${type}`;
+    let url =`${Config.get('baseUrl')}/api/${Config.get('vocabulariesApiEndpoint')}/${type}`;
+    if (size) {
+        url = `${url}?page=1&size=${size}`;
+    }
+
+    return url;
 }
 
 function isVocabulary(obj: any): obj is Vocabulary {
@@ -57,32 +115,12 @@ export const Vocabulary = {
     async get(type: string, forceRefresh = false): Promise<Vocabulary> {
         if (!forceRefresh && Cache.has(type)) return Cache.get(type)!;
 
-        const url = makeUrl(type);
-        const pending = Net.fetchWithTimeout(
-            url,
-            {
-                method: 'GET',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                cache: 'no-cache',
-            },
-            15000
-        );
+        // This needs to be done in double pass because the backend
+        // returns only limited number of item unless we explicitly
+        // ask for the number of vocabulary items to return.
 
-        const resp = await Net.resolveFetch(pending);
-        if (!resp.ok) {
-            throw new Error(`"Error ${resp.status}" response to vocabulary request for "${type}" vocabulary type.`);
-        }
-
-        const json = await resp.json();
-        const voc = json['hits']?.['hits'];
-        if (!voc) {
-            throw new Error(`Unexpected response to vocabulary request for "${type}" vocabulary type.`);
-        }
-        if (!isVocabulary(voc)) {
-            throw new Error(`Vocabulary "${type}" does not conform to the expected schema.`)
-        }
+        const totalHits = await getTotalHits(type);
+        const voc = await getVocabularyItems(type, totalHits);
 
         Cache.set(type, voc);
 

--- a/src/mbdb/vocabulary.ts
+++ b/src/mbdb/vocabulary.ts
@@ -1,6 +1,13 @@
 import { Config } from '../config';
+import { assert } from '../assert';
 import { Net } from '../util/net';
+import { Result } from '../util/result';
 import { Json } from '../util/types';
+
+// The backend may have a cap on how many hits it returns
+// regardless of how many items it actually stores.
+// Unless specified otherwise, use this value as the cap.
+const DefaultMaximumHitsCap = 10000;
 
 export type VocabularyEntry = {
     id: string,
@@ -13,45 +20,129 @@ export type VocabularyEntry = {
 } & Json;
 export type Vocabulary = VocabularyEntry[];
 
-const Cache = new Map<string, Vocabulary>;
+type CachedVocabulary = {
+    isComplete: boolean,
+    data: Vocabulary,
+};
+const Cache = new Map<string, CachedVocabulary>;
+
+function getCached(type: string) {
+    assert(isCached(type), `Vocabulary "${type}" has not been loaded yet`);
+
+    return Cache.get(type)!;
+}
 
 async function getTotalHits(type: string) {
     const url = makeUrl(type);
     const pending = issueRequest(url);
 
-    const resp = await Net.resolveFetch(pending);
-    if (!resp.ok) {
-        throw new Error(`"Error ${resp.status}" response to vocabulary request for "${type}" vocabulary type.`);
-    }
+    const r = await Net.resolveFetchNothrow(pending);
+    if (Result.isOk(r)) {
+        if (!r.data.ok) {
+            throw new Error(`"Error ${r.data.status}" response to vocabulary request for "${type}" vocabulary type.`);
+        }
 
-    const payload = await resp.json();
-    const totalHits = payload['hits']?.['total'];
-    if (typeof totalHits !== 'number' || totalHits < 0) {
-        throw new Error(`Unexpected response to vocabulary request for "${type}" vocabulary type. Invalid number of total hits.`);
-    }
+        const payload = await r.data.json();
+        const totalHits = payload['hits']?.['total'];
+        if (typeof totalHits !== 'number' || totalHits < 0) {
+            throw new Error(`Unexpected response to vocabulary request for "${type}" vocabulary type. Invalid number of total hits.`);
+        }
 
-    return totalHits;
+        return totalHits;
+    } else if (Result.isError(r)) {
+        if (r.error.type === 'timeout') {
+            return 0;
+        } else if (r.error.type === 'error') {
+            throw r.error.e;
+        } else {
+            assert(false, 'Unreachable');
+        }
+    } else {
+        assert(false, 'Unreachable');
+    }
 }
 
 async function getVocabularyItems(type: string, totalHits: number) {
-    const url = makeUrl(type, totalHits);
+    const url = makeUrl(type, { size: totalHits });
+    const pending = issueRequest(url);
+
+    const r = await Net.resolveFetchNothrow(pending);
+    if (Result.isOk(r)) {
+        if (!r.data.ok) {
+            throw new Error(`"Error ${r.data.status}" response to vocabulary request for "${type}" vocabulary type.`);
+        }
+
+        const payload = await r.data.json();
+        try {
+            return vocabularyFromPayload(payload);
+        } catch (e) {
+            throw new Error(`Failed to fetch vocabulary "${type}": ${e}`);
+        }
+    } else if (Result.isError(r)) {
+        if (r.error.type === 'timeout') {
+            return [];
+        } else if (r.error.type === 'error') {
+            throw r.error.e;
+        } else {
+            assert(false, 'Unreachable');
+        }
+    } else {
+        assert(false, 'Unreachable');
+    }
+}
+
+async function fetchById(type: string, id: string): Promise<VocabularyEntry | undefined> {
+    const url = makeUrl(type, { id });
     const pending = issueRequest(url);
 
     const resp = await Net.resolveFetch(pending);
     if (!resp.ok) {
-        throw new Error(`"Error ${resp.status}" response to vocabulary request for "${type}" vocabulary type.`);
+        if (resp.status === 404) {
+            return void 0; // Entry with the given ID does not exist
+        }
+
+        throw new Error(`"Error ${resp.status}" response to vocabulary id lookup request for "${type}" vocabulary type.`);
     }
 
     const payload = await resp.json();
-    const voc = payload['hits']?.['hits'];
-    if (!voc) {
-        throw new Error(`Unexpected response to vocabulary request for "${type}" vocabulary type.`);
-    }
-    if (!isVocabulary(voc)) {
-        throw new Error(`Vocabulary "${type}" does not conform to the expected schema.`)
+    if (!isVocabularyEntry(payload)) {
+        throw new Error(`Unexpected response to vocabulary id lookup request for "${type}" vocabulary type.`);
     }
 
-    return voc;
+    return payload;
+}
+
+async function fetchSuggestions(type: string, query: string) {
+    const url = makeUrl(type, { suggest: query });
+    const pending = issueRequest(url);
+
+    const resp = await Net.resolveFetch(pending);
+    if (!resp.ok) {
+        throw new Error(`"Error ${resp.status}" response to vocabulary suggestion request for "${type}" vocabulary type.`);
+    }
+
+    const payload = await resp.json();
+    try {
+        return vocabularyFromPayload(payload);
+    } catch (e) {
+        throw new Error(`Failed to fetch vocabulary "${type}": ${e}`);
+    }
+}
+
+async function fetchVocabulary(type: string) {
+    const cap = Config.get('vocabulariesApiMaximumHitsCap') ?? DefaultMaximumHitsCap;
+
+    const totalHits = await getTotalHits(type);
+
+    let data: Vocabulary = [];
+    if (totalHits > 0) {
+        data = await getVocabularyItems(type, totalHits);
+    }
+
+    // Tolerate timeouts.
+    // If a vocabulary fetch times out, pretend that we got an empty incomplete vocabulary
+    // This will force the search function to use suggest requests.
+    Cache.set(type, { data, isComplete: totalHits < cap && data.length > 0 });
 }
 
 function issueRequest(url: string) {
@@ -68,7 +159,7 @@ function issueRequest(url: string) {
     );
 }
 
-function makeUrl(type: string, size?: number) {
+function makeUrl(type: string, parameters?: { size?: number, suggest?: string, id?: string }) {
     if (!Config.get('vocabulariesApiEndpoint')) {
         throw new Error('Cannot make a URL for vocabulary API query because the application is misconfigured.');
     }
@@ -77,11 +168,19 @@ function makeUrl(type: string, size?: number) {
     // The inconsistency, or rather lack of thereof, is about the hit you in the face.
     // This URL shall *not* end with a trailing slash, otherwise the API request will fail.
     let url =`${Config.get('baseUrl')}/api/${Config.get('vocabulariesApiEndpoint')}/${type}`;
-    if (size) {
-        url = `${url}?page=1&size=${size}`;
+    if (parameters?.size) {
+        url = `${url}?page=1&size=${parameters.size}`;
+    } else if (parameters?.suggest) {
+        url = `${url}?suggest=${parameters.suggest}`;
+    } else if (parameters?.id) {
+        url = `${url}/${parameters.id}`;
     }
 
     return url;
+}
+
+function isCached(type: string) {
+    return Cache.has(type);
 }
 
 function isVocabulary(obj: any): obj is Vocabulary {
@@ -92,6 +191,18 @@ function isVocabulary(obj: any): obj is Vocabulary {
     }
 
     return true;
+}
+
+function vocabularyFromPayload(payload: any) {
+    const voc = payload['hits']?.['hits'];
+    if (!voc) {
+        throw new Error(`Unexpected response to vocabulary request.`);
+    }
+    if (!isVocabulary(voc)) {
+        throw new Error(`Payload does not conform to the expected schema.`)
+    }
+
+    return voc;
 }
 
 export function isVocabularyEntry(obj: any): obj is VocabularyEntry {
@@ -112,22 +223,56 @@ export function isVocabularyEntry(obj: any): obj is VocabularyEntry {
 }
 
 export const Vocabulary = {
-    async get(type: string, forceRefresh = false): Promise<Vocabulary> {
-        if (!forceRefresh && Cache.has(type)) return Cache.get(type)!;
-
-        // This needs to be done in double pass because the backend
-        // returns only limited number of item unless we explicitly
-        // ask for the number of vocabulary items to return.
-
-        const totalHits = await getTotalHits(type);
-        const voc = await getVocabularyItems(type, totalHits);
-
-        Cache.set(type, voc);
-
-        return voc;
+    getCached(type: string) {
+        return getCached(type).data;
     },
 
-    getCached(type: string) {
-        return Cache.get(type);
+    async getById(type: string, id: string, forceReload = false) {
+        await this.prefetch(type, forceReload);
+        const voc = getCached(type);
+
+        let e = voc.data.find((x) => x.id === id);
+        if (e) {
+            return e;
+        }
+
+        e = await fetchById(type, id);
+        if (e) {
+            voc.data.push(e);
+        }
+
+        return e;
+    },
+
+    async prefetch(type: string, forceReload = false) {
+        if (!isCached(type) || forceReload) {
+            await fetchVocabulary(type);
+        }
+    },
+
+    async search(type: string, query: string, forceReload = false): Promise<VocabularyEntry[]> {
+        await this.prefetch(type, forceReload);
+        const voc = getCached(type);
+
+        const queryLwr = query.toLowerCase();
+        const hits = voc.data.filter((x) => x.title.en.toLowerCase().startsWith(queryLwr));
+
+        if (voc.isComplete) {
+            return hits;
+        } else {
+            if (hits.length === 0) {
+                const suggestionHits = await fetchSuggestions(type, query);
+
+                for (const h of suggestionHits) {
+                    // Check that we are not duplicating entries
+                    if (!voc.data.find((x) => x.id === h.id))
+                        voc.data.push(h);
+                }
+
+                return suggestionHits;
+            } else {
+                return hits;
+            }
+        }
     },
 };

--- a/src/schema/validators.ts
+++ b/src/schema/validators.ts
@@ -41,6 +41,18 @@ function validateVocabulary(v: VocabularyEntry, vocabularyType: string, isRequir
     if (Value.isEmptyVocabularyEntry(Value.vocabularyEntry(id, title, data, false))) {
         return !isRequired;
     } else {
+        // TODO:
+        // We are checking if the ID of the vocabulary entry is a valid ID. An ID is considered valid
+        // if there is an entry with a matching ID in the vocabulary.
+        // Ideally, we would want to query the remote repository on the backend because that is
+        // the determining authority. To do that we would have to issue a network request and
+        // that is an async operation. Unfortunataly, we cannot call async operations from here.
+        //
+        // The next best thing to do is to get the cached copy of the local vocabulary and
+        // check against that. There is, however, no guarantee that the cached copy is a complete
+        // copy of the repome repository. As a result, we may incorrectly flag the data as invalid
+        // This is sad but the only way out would be to asyncify the entire Validator API.
+
         const voc = Vocabulary.getCached(vocabularyType);
         if (!voc) return true; // If we do not have a vocabulary to check against, optimistically assume that the value is okay
 


### PR DESCRIPTION
A request for a vocabulary with no additional parameters may not return the entire vocabulary. To fix the problem, split the vocabulary fetch into two passes. First determine the number of items in the vocabulary and then fetch the entire vocabulary, using the number of items as the request parameter.

@mesemus I don't know if the backend is guaranteed to always return as many items as it is asked for if there is a hard cap. In the latter case the fetch procedure would have to be done in stages.